### PR TITLE
Fix memory leak (gainNodes piling up) by resetting nodes for repeated sounds

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -14,8 +14,12 @@ module.exports = function (player) {
   player.on = function (event, cb) {
     if (arguments.length === 1 && typeof event === 'function') return player.on('event', event)
     var prop = 'on' + event
-    var old = player[prop]
-    player[prop] = old ? chain(old, cb) : cb
+    // @Memory
+    if (player[prop]) {
+      player[prop].push(cb)
+    } else {
+      player[prop] = [cb]
+    }
     return player
   }
   return player

--- a/lib/player.js
+++ b/lib/player.js
@@ -80,8 +80,19 @@ function SamplePlayer (ac, source, options) {
     var opts = options || EMPTY
     when = Math.max(ac.currentTime, when || 0)
     player.emit('start', when, name, opts)
-    var node = createNode(name, buffer, opts)
-    node.id = track(name, node)
+    // cache
+    var node
+    // @Memory check if node should be resetted to prevent memory leak
+    for (var iterator in tracked) {
+      // startTime check prevents repeated sounds cutting off earlier similar sounds
+      if (buffer === tracked[iterator].source.buffer && tracked[iterator].startTime + buffer.duration < when) {
+        node = resetNode(tracked[iterator], buffer, opts)
+      }
+    }
+    if (!node) {
+      node = createNode(name, buffer, opts)
+      node.id = track(name, node)
+    }
     node.env.start(when)
     node.source.start(when)
     player.emit('started', when, node.id, node)
@@ -142,8 +153,8 @@ function SamplePlayer (ac, source, options) {
 
   player.emit = function (event, when, obj, opts) {
     if (player.onevent) player.onevent(event, when, obj, opts)
-    var fn = player['on' + event]
-    if (fn) fn(when, obj, opts)
+    var fnList = player['on' + event]
+    if (fnList) fnList.forEach((fn) => { fn(when, obj, opts) })
   }
 
   return player
@@ -153,6 +164,7 @@ function SamplePlayer (ac, source, options) {
   function track (name, node) {
     node.id = nextId++
     tracked[node.id] = node
+    node.startTime = ac.currentTime
     node.source.onended = function () {
       var now = ac.currentTime
       node.source.disconnect()
@@ -184,6 +196,25 @@ function SamplePlayer (ac, source, options) {
       var stopAt = node.env.stop(time)
       node.source.stop(stopAt)
     }
+    return node
+  }
+
+  /** Reset the node to free up memory (enable garbage collection for GainNode). */
+  function resetNode(oldNode, buffer, options) {
+    var node = oldNode
+    node.gain.value = 0 // the envelope will control the gain
+    node.connect(out)
+
+    node.env = envelope(ac, options, opts)
+    node.env.connect(node.gain)
+
+    node.source = ac.createBufferSource()
+    node.source.buffer = buffer
+    node.source.connect(node)
+    node.source.loop = options.loop || opts.loop
+    node.source.playbackRate.value = centsToRate(options.cents || opts.cents)
+    node.source.loopStart = options.loopStart || opts.loopStart
+    node.source.loopEnd = options.loopEnd || opts.loopEnd
     return node
   }
 }


### PR DESCRIPTION
Playing many repeated sounds over time, e.g. a music sheet, causes memory to leak and build up constantly, the more sounds are played.
![image](https://user-images.githubusercontent.com/33069673/188688814-f9b359a5-2678-48ed-b9d4-c29bab9a6902.png)

The issue is the createNode() function, which always creates new gain nodes, which are not garbage collected.
By caching gain nodes and resetting them instead of creating new nodes, the memory leak can be avoided.

![image](https://user-images.githubusercontent.com/33069673/188689314-066e7fd8-e5c6-4234-80c1-35ea3342bc8c.png)

The fix here is mostly by @Charlottecuc, who didn't have the time to submit a PR (I asked for permission), with a few additions by myself to clean up and prevent stuttering in playback when similar sounds are played shortly after each other and the node is resetted too early.

I'm not expecting this PR to go through as the stutter fix is a bit inelegant, but it works, no more memory buildup during extended playback. So, for anyone looking for a solution, this is one. You can adapt it or improve it.

Unfortunately our original discussion with @Charlottecuc is in a private repository (audio player extension of [OpenSheetMusicDisplay](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay)), but if you need more details, I can add them.